### PR TITLE
[Bug] Fixed Default Search Page Sorting

### DIFF
--- a/src/components/Search/SearchBar.tsx
+++ b/src/components/Search/SearchBar.tsx
@@ -9,7 +9,7 @@ function SearchBar(props: any) {
   // Populate from GET queries
   let text_default: string = URLHelper.populateDefaultFromURL("q", "");
   let genre_default: string = URLHelper.populateDefaultFromURL("genre", "Disregard");
-  let sort_default: string = URLHelper.populateDefaultFromURL("sort", "title");
+  let sort_default: string = URLHelper.populateDefaultFromURL("sort", "default_ascending");
 
   const [text, setText] = useState(text_default);
 

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -16,7 +16,7 @@ async function getData(page: number) {
     // Gets data from inputs by stealing them from the URL (since the values are synced, teehee)
     const q = URLHelper.populateDefaultFromURL("q", "");
     const genre = URLHelper.populateDefaultFromURL("genre", "Disregard");
-    const sort = URLHelper.populateDefaultFromURL("sort", "title");
+    const sort = URLHelper.populateDefaultFromURL("sort", "default_ascending");
 
     let path = `/search?p=${page}&genre=${genre}&sort=${sort}`;
 


### PR DESCRIPTION
# What changed?
Fixed bug w/search page. We were passing old default value for search which, as of yesterday, is invalid on backend.

# How was this accomplished?
Changed default sort to correct one.

# Testing
Ran app before/after changes. Before changes, infinite wait for searches, after, instant list of movies.