### PR TITLE
Settings Page Updates

### DIFF
--- a/src/components/MovieEntry/AddContentWarning.tsx
+++ b/src/components/MovieEntry/AddContentWarning.tsx
@@ -141,7 +141,7 @@ function AddContentWarning(props: any) {
                 leaveFrom="opacity-100 scale-100"
                 leaveTo="opacity-0 scale-95"
               >
-                <Dialog.Panel className="w-full max-w-xl transform overflow-hidden rounded-lg align-middle text-dark-3 shadow-xl transition-all dark:text-light-1">
+                <Dialog.Panel className="w-full max-w-2xl transform overflow-hidden rounded-lg align-middle text-dark-3 shadow-xl transition-all dark:text-light-1">
                   <div className="flex w-full">
                     <div className="w-full rounded-l bg-light-1 p-4 dark:bg-dark-2">
                       <h1 className="ml-1 mb-2 text-lg font-bold">

--- a/src/components/MovieEntry/StreamingButton.tsx
+++ b/src/components/MovieEntry/StreamingButton.tsx
@@ -1,5 +1,8 @@
 // References
 // https://stackoverflow.com/questions/1026069/how-do-i-make-the-first-letter-of-a-string-uppercase-in-javascript
+// https://stackoverflow.com/questions/64709508/display-text-when-hovering-over-an-icon-using-react-icon-library
+
+import Tooltip from "@mui/material/Tooltip";
 
 function StreamingButton(props: any) {
   const streamer = props.streamer.split(" - ")[0];
@@ -8,22 +11,24 @@ function StreamingButton(props: any) {
   else streamType = streamType.charAt(0).toUpperCase() + streamType.slice(1);
 
   return (
-    <div
-      className={`w-28 rounded-lg border border-transparent bg-light-2 text-dark-3 transition delay-100 ease-in-out dark:bg-dark-3 dark:text-light-1`}
-    >
-      <div className="flex items-center px-1">
-        {props.icon && (
-          <img
-            className="my-2 h-8 rounded-lg object-scale-down"
-            src={props.icon}
-            alt={streamer}
-          />
-        )}
-        <div className="my-2 ml-4 font-sans text-sm font-bold">
-          {streamType}
+    <Tooltip title={streamer} placement="top" arrow={true}>
+      <div
+        className={`w-28 rounded-lg border border-transparent bg-light-2 text-dark-3 transition delay-100 ease-in-out dark:bg-dark-3 dark:text-light-1`}
+      >
+        <div className="flex items-center px-1">
+          {props.icon && (
+            <img
+              className="my-2 h-8 rounded-lg object-scale-down"
+              src={props.icon}
+              alt={streamer}
+            />
+          )}
+          <div className="my-2 ml-4 font-sans text-sm font-bold">
+            {streamType}
+          </div>
         </div>
       </div>
-    </div>
+    </Tooltip>
   );
 }
 

--- a/src/components/Settings/CWInput.tsx
+++ b/src/components/Settings/CWInput.tsx
@@ -29,7 +29,8 @@ function CWInput(props: any) {
     // Otherwise, convert the localStorage string to an array
     const cwList = existingList ? JSON.parse(existingList) : {};
 
-    setVisibility(cwList[`${props.name}`]);
+    if (cwList[`${props.name}`]) setVisibility(cwList[`${props.name}`]);
+    else setVisibility("show");
   }, [props.name]);
 
   useEffect(() => {
@@ -64,7 +65,9 @@ function CWInput(props: any) {
               {props.name}
             </h2>
           </div>
-          {message.length !== 0 && <p className="text-light-3">{message}</p>}
+          {message.length !== 0 && (
+            <p className="text-dark-1 dark:text-light-3">{message}</p>
+          )}
         </div>
         <div className="flex w-full justify-between">
           <label>

--- a/src/components/Settings/CWInput.tsx
+++ b/src/components/Settings/CWInput.tsx
@@ -51,18 +51,18 @@ function CWInput(props: any) {
       <div className="flex justify-between">
         <div className="w-full">
           <div className="flex">
-            <h2 className="text-xl text-dark-3 dark:text-light-1">
-              {props.name}
-            </h2>
             <button
               type="button"
               onClick={() => handleClick()}
               className={
-                "ml-2 h-min rounded-full border-primary-2 bg-primary-2 px-3 py-1 italic text-dark-3 transition delay-100 ease-in-out hover:border-primary-1 hover:bg-primary-1"
+                "mr-2 h-min rounded-full border-primary-2 bg-primary-2 px-3 py-1 italic text-dark-3 transition delay-100 ease-in-out hover:border-primary-1 hover:bg-primary-1"
               }
             >
               i
             </button>
+            <h2 className="text-xl text-dark-3 dark:text-light-1">
+              {props.name}
+            </h2>
           </div>
           {message.length !== 0 && <p className="text-light-3">{message}</p>}
         </div>

--- a/src/components/Settings/ContentSubmission.tsx
+++ b/src/components/Settings/ContentSubmission.tsx
@@ -3,6 +3,9 @@ import { IoIosWarning, IoIosArrowBack } from "react-icons/io";
 import { Fragment, useEffect, useState } from "react";
 import Backend from "../../helpers/Backend";
 import { FaSpinner } from "react-icons/fa";
+import WarningButton from "./WarningButton";
+import { AiFillDelete } from "react-icons/ai";
+import EditContentSubmission from "./EditContentSubmission";
 
 function getTime(time: number): String {
   let hours: number = Math.floor(time / 60);
@@ -48,6 +51,8 @@ function ContentSubmission(props: any) {
   useEffect(() => {
     findMovie(props.cw.movie_id, setTitle);
   }, [props.cw.movie_id]);
+
+  const deleteSubmission = () => {};
 
   return (
     <>
@@ -132,6 +137,14 @@ function ContentSubmission(props: any) {
                         <p className="text-sm">{props.cw.desc}</p>
                       </div>
                     )}
+                  </div>
+                  <div className="my-2 flex w-full justify-center">
+                    <EditContentSubmission cw={props.cw} title={title} />
+                    <WarningButton
+                      name="Delete"
+                      icon={<AiFillDelete />}
+                      handleClick={deleteSubmission}
+                    />
                   </div>
                   <div className="my-2 flex w-full justify-center">
                     <button

--- a/src/components/Settings/ContentSubmission.tsx
+++ b/src/components/Settings/ContentSubmission.tsx
@@ -6,6 +6,7 @@ import { FaSpinner } from "react-icons/fa";
 import WarningButton from "./WarningButton";
 import { AiFillDelete } from "react-icons/ai";
 import EditContentSubmission from "./EditContentSubmission";
+import Toast from "../../helpers/Toast";
 
 function getTime(time: number): String {
   let hours: number = Math.floor(time / 60);
@@ -52,7 +53,29 @@ function ContentSubmission(props: any) {
     findMovie(props.cw.movie_id, setTitle);
   }, [props.cw.movie_id]);
 
-  const deleteSubmission = () => {};
+  const deleteSubmission = () => {
+    const cwInfo = {
+      name: "None",
+      movie_id: props.cw.movie_id,
+      time: props.cw.time,
+      desc: props.cw.desc,
+    };
+    let path = `cw/${props.cw.id}`;
+    Backend.postRequest(path, cwInfo)
+      .then((resp: any) => {
+        const data: number = resp.statusCode;
+        if (data < 400) {
+          window.location.pathname = `/settings/profile/`;
+        } else {
+          Toast.toast(resp.jsonResponse.detail);
+        }
+      })
+      .catch((err: any) => {
+        Toast.toast(
+          "Could not connect to the server. Please try again in a few minutes!"
+        );
+      });
+  };
 
   return (
     <>

--- a/src/components/Settings/ContentSubmission.tsx
+++ b/src/components/Settings/ContentSubmission.tsx
@@ -46,6 +46,8 @@ function findMovie(movieId: string, setTitle: any) {
 
 function ContentSubmission(props: any) {
   const [isOpen, setIsOpen] = useState(false);
+  const [checkDelete, setCheckDelete] = useState(false);
+  const [warning, setWarning] = useState("");
   const [title, setTitle] = useState("");
   const headerColor = props.flag ? "bg-secondary-3" : "bg-dark-3";
 
@@ -53,7 +55,20 @@ function ContentSubmission(props: any) {
     findMovie(props.cw.movie_id, setTitle);
   }, [props.cw.movie_id]);
 
+  const closeModal = () => {
+    setWarning("");
+    setCheckDelete(false);
+    setIsOpen(false);
+  };
+
   const deleteSubmission = () => {
+    if (checkDelete === false) {
+      setWarning(
+        "Are you sure you want to do this? This action will be permanent?"
+      );
+      setCheckDelete(true);
+      return;
+    }
     const cwInfo = {
       name: "None",
       movie_id: props.cw.movie_id,
@@ -99,11 +114,7 @@ function ContentSubmission(props: any) {
         </div>
       </button>
       <Transition appear show={isOpen} as={Fragment}>
-        <Dialog
-          as="div"
-          className="relative z-10"
-          onClose={() => setIsOpen(false)}
-        >
+        <Dialog as="div" className="relative z-10" onClose={closeModal}>
           <Transition.Child
             as={Fragment}
             enter="ease-out duration-300"
@@ -169,10 +180,15 @@ function ContentSubmission(props: any) {
                       handleClick={deleteSubmission}
                     />
                   </div>
+                  {warning.length !== 0 && (
+                    <div className="my-1 flex w-full text-center text-warning">
+                      {warning}
+                    </div>
+                  )}
                   <div className="my-2 flex w-full justify-center">
                     <button
                       className="flex items-center rounded-lg border border-transparent bg-transparent p-1 text-dark-3 transition delay-100 ease-in-out hover:border-secondary-2 dark:text-light-1 dark:hover:border-light-3"
-                      onClick={() => setIsOpen(false)}
+                      onClick={closeModal}
                     >
                       <IoIosArrowBack className="text-lg" />
                       <div className="pr-1 text-sm">Back</div>

--- a/src/components/Settings/EditContentSubmission.tsx
+++ b/src/components/Settings/EditContentSubmission.tsx
@@ -1,7 +1,3 @@
-// References
-// https://mui.com/x/react-date-pickers/time-field/
-// https://day.js.org/docs/en/get-set/minute
-
 import { Dialog, Transition } from "@headlessui/react";
 import { IoIosArrowBack } from "react-icons/io";
 import { BsPlusLg } from "react-icons/bs";
@@ -14,6 +10,7 @@ import dayjs, { Dayjs } from "dayjs";
 import { TimeField } from "@mui/x-date-pickers/TimeField";
 import { LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import { FiEdit2 } from "react-icons/fi";
 
 async function getList(setDropdownList: any) {
   let path = "/names";
@@ -28,17 +25,28 @@ async function getList(setDropdownList: any) {
   setDropdownList(dropdownList);
 }
 
-function AddContentWarning(props: any) {
+function EditContentSubmission(props: any) {
   const [isOpen, setIsOpen] = useState(false);
   const [contentWarningName, setContentWarningName] = useState("");
   const [contentWarningSummary, setContentWarningSummary] = useState("");
-  const [submissionSummary, setSubmissionSummary] = useState("");
+  const [submissionSummary, setSubmissionSummary] = useState(props.cw.desc);
   const [dropdownList, setDropdownList] = useState([]);
   const [error, setError] = useState("");
   const [fromTime, setFromTime] = useState<Dayjs | null>(
     dayjs("2022-04-17T00:00")
   );
   const [toTime, setToTime] = useState<Dayjs | null>(dayjs("2022-04-17T00:00"));
+
+  const getStartAndEnd = (cwTimeObject: any) => {
+    const start = cwTimeObject[0];
+    let hours: number = Math.floor(start / 60);
+    let mins: number = start % 60;
+    setFromTime(dayjs().set("hour", hours).set("minute", mins));
+    const end = cwTimeObject[1];
+    hours = Math.floor(end / 60);
+    mins = end % 60;
+    setToTime(dayjs().set("hour", hours).set("minute", mins));
+  };
 
   useEffect(() => {
     getList(setDropdownList);
@@ -62,7 +70,8 @@ function AddContentWarning(props: any) {
   const openModal = () => {
     setError("");
     setIsOpen(true);
-    handleWarningChange("Abandonment");
+    handleWarningChange(props.cw.name);
+    getStartAndEnd(props.cw.time[0]);
   };
 
   const submitCW = () => {
@@ -106,12 +115,11 @@ function AddContentWarning(props: any) {
 
   return (
     <>
-      <button
-        onClick={() => openModal()}
-        className="text-2xl text-dark-3 transition duration-100 ease-in-out hover:opacity-50 dark:text-light-1"
-      >
-        <BsPlusLg />
-      </button>
+      <Primary2Button
+        handleClick={() => openModal()}
+        name="Edit"
+        icon={<FiEdit2 />}
+      />
       <Transition appear show={isOpen} as={Fragment}>
         <Dialog
           as="div"
@@ -145,7 +153,7 @@ function AddContentWarning(props: any) {
                   <div className="flex w-full">
                     <div className="w-full rounded-l bg-light-1 p-4 dark:bg-dark-2">
                       <h1 className="ml-1 mb-2 text-lg font-bold">
-                        Submit Content Warning
+                        {props.title}
                       </h1>
                       <div className="flex w-full">
                         <h2 className="p-2">Content</h2>
@@ -153,6 +161,7 @@ function AddContentWarning(props: any) {
                           id="selectedCw"
                           options={dropdownList}
                           handleChange={handleDropdown}
+                          default={props.cw.name}
                         />
                       </div>
                       <div className="flex items-center">
@@ -176,7 +185,7 @@ function AddContentWarning(props: any) {
                       <div className="flex">
                         <h2 className="p-2">Summary</h2>
                         <TextBox
-                          value={submissionSummary}
+                          defaultValue={submissionSummary}
                           handleChange={(newValue: any) =>
                             setSubmissionSummary(newValue.target.value)
                           }
@@ -217,4 +226,4 @@ function AddContentWarning(props: any) {
   );
 }
 
-export default AddContentWarning;
+export default EditContentSubmission;

--- a/src/pages/MovieEntry.tsx
+++ b/src/pages/MovieEntry.tsx
@@ -206,6 +206,7 @@ function MovieEntry() {
         <div className="my-5 flex justify-between text-dark-3 dark:text-light-1">
           <h1 className="text-3xl font-bold">Content Warnings</h1>
           {localStorage.getItem("token") !== undefined &&
+            localStorage.getItem("token") !== null &&
             localStorage.getItem("token") !== "" && (
               <AddContentWarning movieId={movieId} />
             )}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -36,7 +36,7 @@ function Settings() {
       <div className="relative mb-10 mt-32 h-fit sm:flex lg:mx-20">
         <Tabs page="triggers" />
         <form className="w-full rounded-lg bg-light-2 py-4 px-8 dark:bg-dark-1">
-          <div className="sticky top-20 z-10 flex items-center justify-between bg-light-2 py-2 dark:bg-dark-1">
+          <div className="sticky top-20 z-5 flex items-center justify-between bg-light-2 py-2 dark:bg-dark-1">
             <h2 className="w-full text-xl text-dark-3 dark:text-light-1">
               Name
             </h2>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -36,16 +36,14 @@ function Settings() {
       <div className="relative mb-10 mt-32 h-fit sm:flex lg:mx-20">
         <Tabs page="triggers" />
         <form className="w-full rounded-lg bg-light-2 py-4 px-8 dark:bg-dark-1">
-          <div>
-            <div className="flex justify-between">
-              <h2 className="w-full text-xl text-dark-3 dark:text-light-1">
-                Name
-              </h2>
-              <div className="flex w-full justify-between text-xl text-dark-3 dark:text-light-1">
-                <h1>Show</h1>
-                <h1>Warn</h1>
-                <h1>Hide</h1>
-              </div>
+          <div className="sticky top-20 z-10 flex items-center justify-between bg-light-2 py-2 dark:bg-dark-1">
+            <h2 className="w-full text-xl text-dark-3 dark:text-light-1">
+              Name
+            </h2>
+            <div className="flex w-full justify-between text-xl text-dark-3 dark:text-light-1">
+              <h1>Show</h1>
+              <h1>Warn</h1>
+              <h1>Hide</h1>
             </div>
           </div>
           {cwList.map((cw: any, index: any) => (


### PR DESCRIPTION
# What changed?
- Editing and Deleting CWs from settings
- Information buttons now to left of cw names
- Header of the CW tab now follows user through page
- Tooltips for streaming buttons

# How was this accomplished?
Tooltip from MaterialUI, rest using Backend endpoints and tailwind docs

# Testing
`npm start`

# Related Issues or Work Items
- Closes #24 #31 #32 
- Things that bug me/could be improved: Header of cw tab follows user, but annoying gap between overall header and cw header
- Not really sure what best experience for warning user they are deleting CW, best i came up with was putting up text in the window

